### PR TITLE
Bugfix

### DIFF
--- a/spells/admin.js
+++ b/spells/admin.js
@@ -142,7 +142,7 @@ let Admin_addmember = (args, ctx) => {
       let access_level = 'Recruit';
       console.log(`tguser: ${tguser}`);
       console.log(`nick: ${nick}`);
-      if (!tguser || !nick){
+      if (!tguser || !nick  || !isNaN(nick)){
         reject(Admin_addmember_usage);
       } else { 
         let mentions = await ctx.mentions.get(ctx.message);


### PR DESCRIPTION
Fixed bug causing crash in addmember command when a number was entered for the pa-nick

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)


# Checklist
- [x] I have tested this code
